### PR TITLE
[IMP][FIX] stock_zipcube: show pop-up after scanning to press refresh

### DIFF
--- a/stock_cubiscan/models/cubiscan.py
+++ b/stock_cubiscan/models/cubiscan.py
@@ -16,11 +16,9 @@ class CubiscanDevice(models.Model):
     driver = fields.Selection(
         [("cubiscan", "Cubiscan")], required=True, default="cubiscan"
     )
-    device_address = fields.Char("Device IP Address", required=True)
-    port = fields.Integer("Port", required=True)
-    timeout = fields.Integer(
-        "Timeout", help="Timeout in seconds", required=True, default=30
-    )
+    device_address = fields.Char("Device IP Address")
+    port = fields.Integer("Port")
+    timeout = fields.Integer("Timeout", help="Timeout in seconds", default=30)
     warehouse_id = fields.Many2one("stock.warehouse", "Warehouse")
     state = fields.Selection(
         [("not_ready", "Not Ready"), ("ready", "Ready")],
@@ -32,7 +30,7 @@ class CubiscanDevice(models.Model):
     @api.constrains("device_address", "port")
     def _check_connection_infos(self):
         self.ensure_one()
-        if not 1 <= self.port <= 65535:
+        if self.driver == "cubiscan" and (not 1 <= self.port <= 65535):
             raise ValidationError(_("Port must be in range 1-65535"))
 
     def open_wizard(self):

--- a/stock_cubiscan/views/cubiscan_view.xml
+++ b/stock_cubiscan/views/cubiscan_view.xml
@@ -32,9 +32,18 @@
                             name="cubiscan"
                             attrs="{'invisible': [('driver', '!=', 'cubiscan')]}"
                         >
-                            <field name="device_address" />
-                            <field name="port" />
-                            <field name="timeout" />
+                            <field
+                                name="device_address"
+                                attrs="{'required': [('driver', '=', 'cubiscan')]}"
+                            />
+                            <field
+                                name="port"
+                                attrs="{'required': [('driver', '=', 'cubiscan')]}"
+                            />
+                            <field
+                                name="timeout"
+                                attrs="{'required': [('driver', '=', 'cubiscan')]}"
+                            />
                         </group>
                         <group />
                     </group>

--- a/stock_zipcube/__manifest__.py
+++ b/stock_zipcube/__manifest__.py
@@ -9,6 +9,8 @@
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [
+        # For the pop-up message to tell the user to refresh.
+        "web_notify",
         "web_ir_actions_act_view_reload",
         # TODO: extract the common parts in a separate module to avoid pulling
         # unneeded external_dependencies

--- a/stock_zipcube/wizard/cubiscan_wizard.py
+++ b/stock_zipcube/wizard/cubiscan_wizard.py
@@ -22,8 +22,8 @@ class CubiscanWizardLine(models.TransientModel):
 
     def cubiscan_measure(self):
         self.ensure_one()
-        res = super().cubiscan_measure()
         if self.wizard_id.device_id.driver == "zipcube":
             self.scan_requested = True
             self.packaging_id.scan_device_id = self.wizard_id.device_id
+        res = super().cubiscan_measure()
         return res


### PR DESCRIPTION
Before, after scanning with the zipcube, the measurements were
sent to Odoo but the wizard was not refreshed, so this was
confusing to the user. With this PR, a pop-up is shown to the
user that opened the wizard, warning he/she to press the button
that refreshes the screen.

Apart from that, some bugs have been corrected:
* Cubiscan-only fields were required by zipcube (device_address,
  port and timeout). So now they are required only if the device
  is cubiscan (and not zipcube). This has required moving the
  requirement attribute from the field (model) to the view.
* Pressing the button that sets the line that is going to receive
  the measures didn't set correctly the scanning device for the
  package of the line.
* The check for the ports is done only if the device is Cubiscan.
* Measure key max_weight is not supported, so has been changed in
  the code that reads it to weight.